### PR TITLE
Fix IDT issues

### DIFF
--- a/DiskRead.asm
+++ b/DiskRead.asm
@@ -5,7 +5,7 @@ ReadDisk:
 
 	mov ah, 0x02
 	mov bx, PROGRAM_SPACE
-	mov al, 18
+	mov al, 35
 	mov dl, [BOOT_DISK]
 	mov ch, 0x00	
 	mov dh, 0x00

--- a/IDT.asm
+++ b/IDT.asm
@@ -28,14 +28,8 @@ irq0:
 	iretq
 	GLOBAL irq0
 
-	[extern _idt_]
-idtDescriptor:
-	dw 4095
-	dq 0
-	GLOBAL idtDescriptor
-
 InitIDT:
-
+    [extern idtDescriptor]
 	lidt[idtDescriptor]
 	sti
 	

--- a/IDT.cpp
+++ b/IDT.cpp
@@ -6,7 +6,7 @@
 struct IDTDescriptor {
 	uint_16 Limit;
 	uint_64 Base;	
-};
+} __attribute__((packed));
 
 struct IDT_64 {
 	uint_16 offset_1;
@@ -18,10 +18,10 @@ struct IDT_64 {
 	uint_32 zero;
 }__attribute__((packed));
 
-extern IDT_64 _idt_[256];
+IDT_64 _idt_[256];
 extern uint_64 irq0;
 extern "C" void* InitIDT();
-extern IDTDescriptor idtDescriptor;
+IDTDescriptor idtDescriptor = { sizeof(_idt_)-1, (uint_64)&_idt_};
 void InitializeIDT() {
 	PrintStrings(3, "Initializing IDT at ", HexToString(&_idt_), "\n\r");
 	PrintStrings(3, "irq0 is at ", HexToString(&irq0), "\n\r");
@@ -44,7 +44,6 @@ void InitializeIDT() {
 	PrintStrings(2, HexToString(_idt_[1].offset_2), "\n\r");
 	PrintStrings(2, HexToString(_idt_[1].offset_3), "\n\r");
 	PrintStrings(2, HexToString(_idt_[1].zero), "\n\r");
-	idtDescriptor.Base = (uint_64)_idt_;
 	
 	PrintStrings(3, "IDT Size: ", HexToString(idtDescriptor.Limit), "\n\r");
 	PrintStrings(3, "IDT Base: ", HexToString(idtDescriptor.Base), "\n\r");

--- a/link.ld
+++ b/link.ld
@@ -35,7 +35,7 @@ SECTIONS
 	.rodata : ALIGN(0x1000)
 	{
 	_rodata_section = .;
-	*(.rodata)
+	*(.rodata*)
 	_rodata_section_end = .;
 	}
 	
@@ -45,10 +45,5 @@ SECTIONS
 	*(COMMON)
 	*(.bss)
 	_bss_section_end = .;
-	}
-
-	.idt BLOCK(0x1000) : ALIGN(0x1000)
-	{
-	_idt_ = .;
 	}
 }


### PR DESCRIPTION
This is a set of fixes to fix your IDT issues as mentioned in your [Stackoverflow Question](https://stackoverflow.com/questions/62677379/struggling-to-get-interrupts-working-on-x86-64-os). You had 2 `idtDescriptors`, you defined `_idt_` as a label in the linker file rather than just creating an `_idt_` array of `IDT_64` structs. Your `IDTDescriptor` type wasn't packed. I also extended the number of sectors to read to 35 which is effectively the rest of the sectors of head 0 and head 1 of track 0.